### PR TITLE
fix length() warning

### DIFF
--- a/scripts/checkWarnings.js
+++ b/scripts/checkWarnings.js
@@ -3,7 +3,7 @@ function checkWarnings(checkWarnings_input)
     var init_pass2 = checkWarnings_input;
     var warningsFound ="";
 
-    if(init_pass2.includes('length(') == true)
+    if(init_pass2.includes('.length(') == true)
     {
         warningsFound = "•length() method for getting the number of elements in an array (requires GLSL ES 1.2 or later) \n\n".concat(warningsFound);
     }


### PR DESCRIPTION
The length() warning should only trigger with the length() method, not the length() function. It is very helpful that they have the same name and do totally different things. I believe they can be distinguished simply by looking for the `.` method syntax.